### PR TITLE
Enable multi-session core manager and media messaging

### DIFF
--- a/src/core/engines/webjs/session.webjs.core.ts
+++ b/src/core/engines/webjs/session.webjs.core.ts
@@ -92,7 +92,12 @@ import {
   WAHASessionStatus,
   WAMessageAck,
 } from '@waha/structures/enums.dto';
-import { BinaryFile, RemoteFile } from '@waha/structures/files.dto';
+import {
+  BinaryFile,
+  RemoteFile,
+  VoiceBinaryFile,
+  VoiceRemoteFile,
+} from '@waha/structures/files.dto';
 import {
   CreateGroupRequest,
   GroupSortField,
@@ -152,6 +157,12 @@ import {
   isJidStatusBroadcast,
   toCusFormat,
 } from '@waha/core/utils/jids';
+
+type UploadableMedia =
+  | BinaryFile
+  | RemoteFile
+  | VoiceBinaryFile
+  | VoiceRemoteFile;
 
 export interface WebJSConfig {
   webVersion?: string;
@@ -696,20 +707,107 @@ export class WhatsappSessionWebJSCore extends WhatsappSession {
     );
   }
 
-  sendImage(request: MessageImageRequest) {
-    throw new AvailableInPlusVersion();
+  async sendImage(request: MessageImageRequest) {
+    const media = await this.buildMessageMedia(request.file);
+    const options = {
+      ...this.getMessageOptions(request),
+      caption: request.caption,
+    };
+    return this.whatsapp.sendMessage(
+      this.ensureSuffix(request.chatId),
+      media,
+      options,
+    );
   }
 
-  sendFile(request: MessageFileRequest) {
-    throw new AvailableInPlusVersion();
+  async sendFile(request: MessageFileRequest) {
+    const media = await this.buildMessageMedia(request.file);
+    const options = {
+      ...this.getMessageOptions(request),
+      caption: request.caption,
+      sendMediaAsDocument: true,
+    };
+    return this.whatsapp.sendMessage(
+      this.ensureSuffix(request.chatId),
+      media,
+      options,
+    );
   }
 
-  sendVoice(request: MessageVoiceRequest) {
-    throw new AvailableInPlusVersion();
+  async sendVoice(request: MessageVoiceRequest) {
+    const media = await this.buildMessageMedia(request.file);
+    const options = {
+      ...this.getMessageOptions(request),
+      sendAudioAsVoice: true,
+    };
+    return this.whatsapp.sendMessage(
+      this.ensureSuffix(request.chatId),
+      media,
+      options,
+    );
   }
 
   sendButtonsReply(request: MessageButtonReply) {
     throw new AvailableInPlusVersion();
+  }
+
+  private isBinaryMediaFile(
+    file: UploadableMedia,
+  ): file is BinaryFile | VoiceBinaryFile {
+    return 'data' in file;
+  }
+
+  private isRemoteMediaFile(
+    file: UploadableMedia,
+  ): file is RemoteFile | VoiceRemoteFile {
+    return 'url' in file;
+  }
+
+  private sanitizeBase64(data: string): string {
+    const commaIndex = data.indexOf(',');
+    if (commaIndex >= 0) {
+      return data.slice(commaIndex + 1);
+    }
+    return data;
+  }
+
+  private resolveMimetype(file: UploadableMedia): string {
+    return file.mimetype || 'application/octet-stream';
+  }
+
+  private resolveFilename(file: UploadableMedia): string | undefined {
+    if ('filename' in file && file.filename) {
+      return file.filename;
+    }
+    return undefined;
+  }
+
+  private async buildMessageMedia(
+    file: UploadableMedia | undefined,
+  ): Promise<MessageMedia> {
+    if (!file) {
+      throw new UnprocessableEntityException('File payload is required');
+    }
+
+    const mimetype = this.resolveMimetype(file);
+    const filename = this.resolveFilename(file);
+
+    if (this.isBinaryMediaFile(file)) {
+      return new MessageMedia(
+        mimetype,
+        this.sanitizeBase64(file.data),
+        filename,
+      );
+    }
+
+    if (this.isRemoteMediaFile(file)) {
+      const buffer = await this.fetch(file.url);
+      return new MessageMedia(mimetype, buffer.toString('base64'), filename);
+    }
+
+    throw new UnprocessableEntityException(
+      'File must include either data or url content.',
+    );
   }
 
   async sendLocation(request: MessageLocationRequest) {

--- a/src/core/manager.core.ts
+++ b/src/core/manager.core.ts
@@ -43,41 +43,27 @@ import { SessionParams, WhatsappSession } from './abc/session.abc';
 import { EngineConfigService } from './config/EngineConfigService';
 import { WhatsappSessionNoWebCore } from './engines/noweb/session.noweb.core';
 import { WhatsappSessionWebJSCore } from './engines/webjs/session.webjs.core';
-import { DOCS_URL } from './exceptions';
 import { getProxyConfig } from './helpers.proxy';
 import { MediaManager } from './media/MediaManager';
 import { LocalSessionAuthRepository } from './storage/LocalSessionAuthRepository';
 import { LocalStoreCore } from './storage/LocalStoreCore';
 
-export class OnlyDefaultSessionIsAllowed extends UnprocessableEntityException {
-  constructor(name: string) {
-    const encoded = Buffer.from(name, 'utf-8').toString('base64');
-    super(
-      `WAHA Core support only 'default' session. You tried to access '${name}' session (base64: ${encoded}). ` +
-        `If you want to run more then one WhatsApp account - please get WAHA PLUS version. Check this out: ${DOCS_URL}`,
-    );
-  }
-}
-
-enum DefaultSessionStatus {
-  REMOVED = undefined,
-  STOPPED = null,
+interface SessionEntry {
+  config?: SessionConfig;
+  session?: WhatsappSession;
 }
 
 @Injectable()
 export class SessionManagerCore extends SessionManager implements OnModuleInit {
   SESSION_STOP_TIMEOUT = 3000;
 
-  // session - exists and running (or failed or smth)
-  // null - stopped
-  // undefined - removed
-  private session: WhatsappSession | DefaultSessionStatus;
-  private sessionConfig?: SessionConfig;
-  DEFAULT = 'default';
-
+  private readonly sessions: Map<string, SessionEntry> = new Map();
   protected readonly EngineClass: typeof WhatsappSession;
-  protected events2: DefaultMap<WAHAEvents, SwitchObservable<any>>;
   protected readonly engineBootstrap: EngineBootstrap;
+  private readonly eventsBySession: DefaultMap<
+    string,
+    DefaultMap<WAHAEvents, SwitchObservable<any>>
+  >;
 
   constructor(
     config: WhatsappConfigService,
@@ -90,17 +76,14 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     appsService: IAppsService,
   ) {
     super(log, config, gowsConfigService, appsService);
-    this.session = DefaultSessionStatus.STOPPED;
-    this.sessionConfig = null;
     const engineName = this.engineConfigService.getDefaultEngineName();
     this.EngineClass = this.getEngine(engineName);
     this.engineBootstrap = this.getEngineBootstrap(engineName);
-
-    this.events2 = new DefaultMap<WAHAEvents, SwitchObservable<any>>(
-      (key) =>
-        new SwitchObservable((obs$) => {
-          return obs$.pipe(retry(), share());
-        }),
+    this.eventsBySession = new DefaultMap(
+      () =>
+        new DefaultMap<WAHAEvents, SwitchObservable<any>>(() =>
+          new SwitchObservable((obs$) => obs$.pipe(retry(), share())),
+        ),
     );
 
     this.store = new LocalStoreCore(engineName.toLowerCase());
@@ -122,15 +105,56 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     }
   }
 
-  private onlyDefault(name: string) {
-    if (name !== this.DEFAULT) {
-      throw new OnlyDefaultSessionIsAllowed(name);
+  public getSessionEvent(session: string, event: WAHAEvents): Observable<any> {
+    return this.eventsBySession.get(session).get(event);
+  }
+
+  private getOrCreateEntry(name: string): SessionEntry {
+    const existing = this.sessions.get(name);
+    if (existing) {
+      return existing;
+    }
+    const created: SessionEntry = {};
+    this.sessions.set(name, created);
+    return created;
+  }
+
+  private bindSessionEvents(name: string, session: WhatsappSession) {
+    const events = this.eventsBySession.get(name);
+    for (const eventName in WAHAEvents) {
+      const event = WAHAEvents[eventName];
+      const stream$ = session
+        .getEventObservable(event)
+        .pipe(map(populateSessionInfo(event, session)));
+      events.get(event).switch(stream$);
     }
   }
 
+  private unbindSessionEvents(name: string) {
+    if (!this.eventsBySession.has(name)) {
+      return;
+    }
+    const events = this.eventsBySession.get(name);
+    for (const observable of events.values()) {
+      observable.switch(null);
+    }
+  }
+
+  private getRunningSessions(): Record<string, WhatsappSession> {
+    const running: Record<string, WhatsappSession> = {};
+    for (const [sessionName, entry] of this.sessions.entries()) {
+      if (entry.session) {
+        running[sessionName] = entry.session;
+      }
+    }
+    return running;
+  }
+
   async beforeApplicationShutdown(signal?: string) {
-    if (this.session) {
-      await this.stop(this.DEFAULT, true);
+    for (const [name, entry] of this.sessions.entries()) {
+      if (entry.session) {
+        await this.stop(name, true);
+      }
     }
     this.stopEvents();
     await this.engineBootstrap.shutdown();
@@ -141,42 +165,30 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     this.startPredefinedSessions();
   }
 
-  private async clearStorage() {
-    const storage = await this.mediaStorageFactory.build(
-      'all',
-      this.log.logger.child({ name: 'Storage' }),
-    );
-    await storage.purge();
-  }
-
-  //
-  // API Methods
-  //
   async exists(name: string): Promise<boolean> {
-    this.onlyDefault(name);
-    return this.session !== DefaultSessionStatus.REMOVED;
+    return this.sessions.has(name);
   }
 
   isRunning(name: string): boolean {
-    this.onlyDefault(name);
-    return !!this.session;
+    return !!this.sessions.get(name)?.session;
   }
 
   async upsert(name: string, config?: SessionConfig): Promise<void> {
-    this.onlyDefault(name);
-    this.sessionConfig = config;
+    const entry = this.getOrCreateEntry(name);
+    entry.config = config;
   }
 
   async start(name: string): Promise<SessionDTO> {
-    this.onlyDefault(name);
-    if (this.session) {
+    const entry = this.getOrCreateEntry(name);
+    if (entry.session) {
       throw new UnprocessableEntityException(
-        `Session '${this.DEFAULT}' is already started.`,
+        `Session '${name}' is already started.`,
       );
     }
+
     this.log.info({ session: name }, `Starting session...`);
     const logger = this.log.logger.child({ session: name });
-    logger.level = getPinoLogLevel(this.sessionConfig?.debug);
+    logger.level = getPinoLogLevel(entry.config?.debug);
     const loggerBuilder: LoggerBuilder = logger;
 
     const storage = await this.mediaStorageFactory.build(
@@ -184,6 +196,7 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
       loggerBuilder.child({ name: 'Storage' }),
     );
     await storage.init();
+
     const mediaManager = new MediaManager(
       storage,
       this.config.mimetypes,
@@ -191,7 +204,7 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     );
 
     const webhook = new WebhookConductor(loggerBuilder);
-    const proxyConfig = this.getProxyConfig();
+    const proxyConfig = this.getProxyConfig(name);
     const sessionConfig: SessionParams = {
       name,
       mediaManager,
@@ -199,28 +212,27 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
       printQR: this.engineConfigService.shouldPrintQR,
       sessionStore: this.store,
       proxyConfig: proxyConfig,
-      sessionConfig: this.sessionConfig,
-      ignore: this.ignoreChatsConfig(this.sessionConfig),
+      sessionConfig: entry.config,
+      ignore: this.ignoreChatsConfig(entry.config),
     };
+
     if (this.EngineClass === WhatsappSessionWebJSCore) {
       sessionConfig.engineConfig = this.webjsEngineConfigService.getConfig();
     } else if (this.EngineClass === WhatsappSessionGoWSCore) {
       sessionConfig.engineConfig = this.gowsConfigService.getConfig();
     }
+
     await this.sessionAuthRepository.init(name);
     // @ts-ignore
     const session = new this.EngineClass(sessionConfig);
-    this.session = session;
-    this.updateSession();
+    entry.session = session;
+    this.bindSessionEvents(name, session);
 
-    // configure webhooks
-    const webhooks = this.getWebhooks();
+    const webhooks = this.getWebhooks(entry.config);
     webhook.configure(session, webhooks);
 
-    // Apps
     await this.configureApps(session);
 
-    // start session
     await session.start();
     logger.info('Session has been started.');
     return {
@@ -230,35 +242,16 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     };
   }
 
-  private updateSession() {
-    if (!this.session) {
-      return;
-    }
-    const session: WhatsappSession = this.session as WhatsappSession;
-    for (const eventName in WAHAEvents) {
-      const event = WAHAEvents[eventName];
-      const stream$ = session
-        .getEventObservable(event)
-        .pipe(map(populateSessionInfo(event, session)));
-      this.events2.get(event).switch(stream$);
-    }
-  }
-
-  getSessionEvent(session: string, event: WAHAEvents): Observable<any> {
-    return this.events2.get(event);
-  }
-
   async stop(name: string, silent: boolean): Promise<void> {
-    this.onlyDefault(name);
-    if (!this.isRunning(name)) {
+    const entry = this.sessions.get(name);
+    if (!entry?.session) {
       this.log.debug({ session: name }, `Session is not running.`);
       return;
     }
 
     this.log.info({ session: name }, `Stopping session...`);
     try {
-      const session = this.getSession(name);
-      await session.stop();
+      await entry.session.stop();
     } catch (err) {
       this.log.warn(`Error while stopping session '${name}'`);
       if (!silent) {
@@ -266,16 +259,16 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
       }
     }
     this.log.info({ session: name }, `Session has been stopped.`);
-    this.session = DefaultSessionStatus.STOPPED;
-    this.updateSession();
+    entry.session = undefined;
+    this.unbindSessionEvents(name);
     await sleep(this.SESSION_STOP_TIMEOUT);
   }
 
   async unpair(name: string) {
-    if (!this.session) {
+    const session = this.sessions.get(name)?.session;
+    if (!session) {
       return;
     }
-    const session = this.session as WhatsappSession;
 
     this.log.info({ session: name }, 'Unpairing the device from account...');
     await session.unpair().catch((err) => {
@@ -285,24 +278,31 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
   }
 
   async logout(name: string): Promise<void> {
-    this.onlyDefault(name);
     await this.sessionAuthRepository.clean(name);
   }
 
   async delete(name: string): Promise<void> {
-    this.onlyDefault(name);
-    this.session = DefaultSessionStatus.REMOVED;
-    this.updateSession();
-    this.sessionConfig = undefined;
+    const entry = this.sessions.get(name);
+    if (!entry) {
+      return;
+    }
+
+    if (entry.session) {
+      await this.stop(name, true);
+    }
+
+    this.sessions.delete(name);
+    if (this.eventsBySession.has(name)) {
+      const events = this.eventsBySession.get(name);
+      complete(events);
+      this.eventsBySession.delete(name);
+    }
   }
 
-  /**
-   * Combine per session and global webhooks
-   */
-  private getWebhooks() {
+  private getWebhooks(config?: SessionConfig) {
     let webhooks: WebhookConfig[] = [];
-    if (this.sessionConfig?.webhooks) {
-      webhooks = webhooks.concat(this.sessionConfig.webhooks);
+    if (config?.webhooks) {
+      webhooks = webhooks.concat(config.webhooks);
     }
     const globalWebhookConfig = this.config.getWebhookConfig();
     if (globalWebhookConfig) {
@@ -311,65 +311,54 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     return webhooks;
   }
 
-  /**
-   * Get either session's or global proxy if defined
-   */
-  protected getProxyConfig(): ProxyConfig | undefined {
-    if (this.sessionConfig?.proxy) {
-      return this.sessionConfig.proxy;
+  protected getProxyConfig(name: string): ProxyConfig | undefined {
+    const entry = this.sessions.get(name);
+    if (entry?.config?.proxy) {
+      return entry.config.proxy;
     }
-    if (!this.session) {
-      return undefined;
-    }
-    const sessions = { [this.DEFAULT]: this.session as WhatsappSession };
-    return getProxyConfig(this.config, sessions, this.DEFAULT);
+    const sessions = this.getRunningSessions();
+    return getProxyConfig(this.config, sessions, name);
   }
 
   getSession(name: string): WhatsappSession {
-    this.onlyDefault(name);
-    const session = this.session;
+    const session = this.sessions.get(name)?.session;
     if (!session) {
       throw new NotFoundException(
         `We didn't find a session with name '${name}'.\n` +
           `Please start it first by using POST /api/sessions/${name}/start request`,
       );
     }
-    return session as WhatsappSession;
+    return session;
   }
 
   async getSessions(all: boolean): Promise<SessionInfo[]> {
-    if (this.session === DefaultSessionStatus.STOPPED && all) {
-      return [
-        {
-          name: this.DEFAULT,
+    const sessions: SessionInfo[] = [];
+    for (const [name, entry] of this.sessions.entries()) {
+      if (entry.session) {
+        const session = entry.session;
+        sessions.push({
+          name: session.name,
+          status: session.status,
+          config: session.sessionConfig,
+          me: session.getSessionMeInfo(),
+        });
+      } else if (all) {
+        sessions.push({
+          name: name,
           status: WAHASessionStatus.STOPPED,
-          config: this.sessionConfig,
+          config: entry.config,
           me: null,
-        },
-      ];
+        });
+      }
     }
-    if (this.session === DefaultSessionStatus.REMOVED && all) {
-      return [];
+    if (!all) {
+      return sessions;
     }
-    if (!this.session && !all) {
-      return [];
-    }
-
-    const session = this.session as WhatsappSession;
-    const me = session?.getSessionMeInfo();
-    return [
-      {
-        name: session.name,
-        status: session.status,
-        config: session.sessionConfig,
-        me: me,
-      },
-    ];
+    sessions.sort((a, b) => a.name.localeCompare(b.name));
+    return sessions;
   }
 
-  private async fetchEngineInfo() {
-    const session = this.session as WhatsappSession;
-    // Get engine info
+  private async fetchEngineInfo(session?: WhatsappSession) {
     let engineInfo = {};
     if (session) {
       try {
@@ -381,26 +370,40 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
         );
       }
     }
-    const engine = {
+    return {
       engine: session?.engine,
       ...engineInfo,
     };
-    return engine;
   }
 
   async getSessionInfo(name: string): Promise<SessionDetailedInfo | null> {
-    this.onlyDefault(name);
-    const sessions = await this.getSessions(true);
-    if (sessions.length === 0) {
+    const entry = this.sessions.get(name);
+    if (!entry) {
       return null;
     }
-    const session = sessions[0];
-    const engine = await this.fetchEngineInfo();
-    return { ...session, engine: engine };
+    const session = entry.session;
+    const baseInfo: SessionInfo = session
+      ? {
+          name: session.name,
+          status: session.status,
+          config: session.sessionConfig,
+          me: session.getSessionMeInfo(),
+        }
+      : {
+          name: name,
+          status: WAHASessionStatus.STOPPED,
+          config: entry.config,
+          me: null,
+        };
+    const engine = await this.fetchEngineInfo(session);
+    return { ...baseInfo, engine };
   }
 
   protected stopEvents() {
-    complete(this.events2);
+    for (const events of this.eventsBySession.values()) {
+      complete(events);
+    }
+    this.eventsBySession.clear();
   }
 
   async onModuleInit() {
@@ -411,5 +414,13 @@ export class SessionManagerCore extends SessionManager implements OnModuleInit {
     await this.store.init();
     const knex = this.store.getWAHADatabase();
     await this.appsService.migrate(knex);
+  }
+
+  private async clearStorage() {
+    const storage = await this.mediaStorageFactory.build(
+      'all',
+      this.log.logger.child({ name: 'Storage' }),
+    );
+    await storage.purge();
   }
 }


### PR DESCRIPTION
## Summary
- replace the single-session core manager with a map-based implementation that can start, stop, and describe multiple simultaneous WhatsApp sessions
- enable whatsapp-web.js sessions to send images, generic documents, and voice notes by building MessageMedia payloads from base64 or remote files

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68d346289b9c832f9c3f4e3a0a86c543